### PR TITLE
security: pin axios to exact lockfile version 1.7.9 (supply chain fix)

### DIFF
--- a/frontend/sales-agent-crew/package.json
+++ b/frontend/sales-agent-crew/package.json
@@ -12,7 +12,7 @@
     "@clerk/vue": "^1.1.2",
     "@headlessui/vue": "^1.7.23",
     "@heroicons/vue": "^2.2.0",
-    "axios": "^1.7.9",
+    "axios": "1.7.9",
     "chart.js": "^4.4.7",
     "dompurify": "^3.2.4",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Summary

Pins \`axios\` to its exact currently-installed version (\`1.7.9\`) to prevent silent upgrades to the malicious \`axios@1.14.1\` release, which pulls in \`plain-crypto-js@4.2.1\` (a supply chain dropper).

- **Attack vector:** \`^1.7.9\` allows \`npm install\` on a fresh machine to resolve to \`1.14.1\`
- **This change:** \`^1.7.9\` → \`1.7.9\` in \`frontend/sales-agent-crew/package.json\`

No functional change — installed version is identical to what's already in \`package-lock.json\`.

## Suggested reviewer
@anu-wandb (Anu Vatsa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)